### PR TITLE
fix(): reduce load by reducing request frquency

### DIFF
--- a/custom_components/min_renovasjon/coordinator.py
+++ b/custom_components/min_renovasjon/coordinator.py
@@ -24,7 +24,7 @@ class MinRenovasjonCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(hours=1),
+            update_interval=timedelta(hours=24),
         )
         self.min_renovasjon = MinRenovasjon(
             entry.data[CONF_STREET_NAME],


### PR DESCRIPTION
No need to fetch hourly I think, since dates seldom (or never?) change. And if they do, I think catching those within 24 hours should be fine. Right now I think users are getting rate limited due to too frequent polling.