### PR TITLE
Get fraction names from API

### DIFF
--- a/custom_components/min_renovasjon/__init__.py
+++ b/custom_components/min_renovasjon/__init__.py
@@ -1,16 +1,40 @@
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    CONF_STREET_NAME,
+    CONF_STREET_CODE,
+    CONF_HOUSE_NO,
+    CONF_COUNTY_ID,
+    DEFAULT_DATE_FORMAT,
+)
 from .coordinator import MinRenovasjonCoordinator
+from .min_renovasjon import MinRenovasjon
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
+_LOGGER = logging.getLogger(__name__)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    coordinator = MinRenovasjonCoordinator(hass, entry)
+    """Set up Min Renovasjon from a config entry."""
+    _LOGGER.debug("Setting up Min Renovasjon")
+    api = MinRenovasjon(
+        entry.data[CONF_STREET_NAME],
+        entry.data[CONF_STREET_CODE],
+        entry.data[CONF_HOUSE_NO],
+        entry.data[CONF_COUNTY_ID],
+        DEFAULT_DATE_FORMAT
+    )
+    await api.get_fraction_types()
+    coordinator = MinRenovasjonCoordinator(hass, api)
+
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/min_renovasjon/const.py
+++ b/custom_components/min_renovasjon/const.py
@@ -6,32 +6,6 @@ CONF_STREET_NAME: Final = "street_name"
 CONF_STREET_CODE: Final = "street_code"
 CONF_HOUSE_NO: Final = "house_no"
 CONF_COUNTY_ID: Final = "county_id"
-CONF_DATE_FORMAT: Final = "date_format"
-CONF_FRACTIONS: Final = "fractions"
 DEFAULT_DATE_FORMAT: Final = "%d/%m/%Y"
 
 COORDINATOR: Final = "coordinator"
-
-FRACTION_IDS: Final[dict[int, str]] = {
-    1: "Restavfall",
-    2: "Papir",
-    3: "Matavfall",
-    4: "Glass/Metallemballasje",
-    5: "Drikkekartonger",
-    6: "Spesialavfall",
-    7: "Plastemballasje",
-    8: "Trevirke",
-    9: "Tekstiler",
-    10: "Hageavfall",
-    11: "Metaller",
-    12: "Hvitevarer/EE-avfall",
-    13: "Papp",
-    14: "Møbler",
-    19: "Plastemballasje",
-    23: "Nedgravd løsning",
-    24: "GlassIGLO",
-    25: "Farlig avfall",
-    26: "Matavfall hytter",
-    27: "Restavfall hytter",
-    28: "Papir hytter"
-}

--- a/custom_components/min_renovasjon/coordinator.py
+++ b/custom_components/min_renovasjon/coordinator.py
@@ -6,39 +6,27 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    DOMAIN,
-    CONF_STREET_NAME,
-    CONF_STREET_CODE,
-    CONF_HOUSE_NO,
-    CONF_COUNTY_ID,
-    DEFAULT_DATE_FORMAT,
-)
+from .const import DOMAIN
 from .min_renovasjon import MinRenovasjon
 
 _LOGGER = logging.getLogger(__name__)
 
 class MinRenovasjonCoordinator(DataUpdateCoordinator):
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    fractions = []
+
+    def __init__(self, hass: HomeAssistant, min_renovasjon: MinRenovasjon) -> None:
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(hours=24),
         )
-        self.min_renovasjon = MinRenovasjon(
-            entry.data[CONF_STREET_NAME],
-            entry.data[CONF_STREET_CODE],
-            entry.data[CONF_HOUSE_NO],
-            entry.data[CONF_COUNTY_ID],
-            DEFAULT_DATE_FORMAT
-        )
-        self.fractions = []
+        self.min_renovasjon = min_renovasjon
 
     async def _async_update_data(self):
         try:
             _LOGGER.debug("Starting data update in coordinator")
-            await self.hass.async_add_executor_job(self.min_renovasjon.refresh_calendar)
+            await self.min_renovasjon.refresh_calendar()
             self.fractions = [str(fraction[0]) for fraction in self.min_renovasjon.calender_list]
             _LOGGER.debug("Fractions after refresh: %s", self.fractions)
             

--- a/custom_components/min_renovasjon/sensor.py
+++ b/custom_components/min_renovasjon/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, FRACTION_IDS
+from .const import DOMAIN
 from .coordinator import MinRenovasjonCoordinator
 
 import logging
@@ -36,7 +36,7 @@ class MinRenovasjonNextCollectionSensor(CoordinatorEntity, SensorEntity):
                 date_str = collection_date.date().isoformat()
                 if date_str not in next_collections:
                     next_collections[date_str] = []
-                next_collections[date_str].append(FRACTION_IDS.get(int(fraction_id), f"Unknown {fraction_id}"))
+                next_collections[date_str].append(self.coordinator.min_renovasjon.get_fraction_name(fraction_id))
 
             if not next_collections:
                 return "Unavailable"
@@ -83,7 +83,7 @@ class MinRenovasjonSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._fraction_id = fraction_id
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{fraction_id}"
-        self._attr_name = f"Min Renovasjon {FRACTION_IDS.get(int(fraction_id), f'Unknown {fraction_id}')}"
+        self._attr_name = f"Min Renovasjon {coordinator.min_renovasjon.get_fraction_name(fraction_id)}"
         _LOGGER.debug("Initialized sensor for fraction %s with name %s", fraction_id, self._attr_name)
 
     @property
@@ -129,7 +129,7 @@ class MinRenovasjonSensor(CoordinatorEntity, SensorEntity):
                     if isinstance(next_date, datetime):
                         days_until = (next_date.date() - datetime.now().date()).days
                         attributes["days_until"] = max(0, days_until)
-                attributes["fraction_name"] = FRACTION_IDS.get(int(self._fraction_id), f"Unknown {self._fraction_id}")
+                attributes["fraction_name"] = self.coordinator.min_renovasjon.get_fraction_name(self._fraction_id)
             _LOGGER.debug("Extra state attributes for fraction %s: %s", self._fraction_id, attributes)
         except Exception as e:
             _LOGGER.error("Error getting extra state attributes for fraction %s: %s", self._fraction_id, e)


### PR DESCRIPTION
Thank you for a great integration! I noticed that my county uses different fraction ids for some of the fractions than those hard coded in `const.py`. Fortunately, the correct fractions names are available on the API, so here is a PR that uses those instead.

I also noticed that the fraction types were retrieved whenever the calendar was updated, so I moved that to startup initialization. Or is it necessary to refetch the fraction types?

Finally, I rewrote to use `aiohttp` instead of `requests` so the api is now async. Let me know if you would prefer this change in a separate PR.